### PR TITLE
Explicitly use subdir-objects in automake init

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_INIT([varnish-agent], [2.2])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_CONFIG_HEADER(config.h)
 
-AM_INIT_AUTOMAKE([-Wall -Werror foreign parallel-tests])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign parallel-tests subdir-objects])
 
 # Check for rst utilities
 AC_ARG_WITH([rst2man],


### PR DESCRIPTION
If automake is switched to treated warnings as errors, the building process fails because of this option not being explicitly allowed.
Some major Linux vendors have done this, Debian included.

Please merge.
