### PR TITLE
Add a local backend for the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ config.h
 config.log
 config.status
 .deps/
+.dirstamp
 stamp-h1
 tags
 compile

--- a/tests/badvarnishd.sh
+++ b/tests/badvarnishd.sh
@@ -7,6 +7,7 @@ PHASE=1
 VARNISH_PORT=$(( 1024 + ( $RANDOM % 48000 ) ))
 
 init_password
+start_backend
 phase() {
 	now=$(date +%s)
 	echo
@@ -122,5 +123,6 @@ test_it GET status "" "Child in state stopped"
 phase "Cleanup"
 stop_agent
 stop_varnish
+stop_backend
 rm -fr $TMPDIR
 exit $ret

--- a/tests/data/boot.vcl
+++ b/tests/data/boot.vcl
@@ -1,1 +1,1 @@
-backend default { .host = "kly.no"; }
+backend default { .host = "localhost"; }

--- a/tests/empty_response_backend.py
+++ b/tests/empty_response_backend.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+import BaseHTTPServer
+
+class EmptyResponseHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+
+    def send_empty_response(self):
+        self.send_response(204)
+        self.end_headers()
+
+    def do_GET(self):
+        self.send_empty_response()
+
+    def do_HEAD(self):
+        self.send_empty_response()
+
+    def do_POST(self):
+        self.send_empty_response()
+
+if __name__ == '__main__':
+    BaseHTTPServer.test(EmptyResponseHandler)


### PR DESCRIPTION
This is a follow-up of #94, it will add offline capabilities to the test suite.

All tests pass consistently except `ban.sh` which still sometimes fails on my x86_64 machine. Starting `varnishd` with `ban_lurker_sleep=0` doesn't help at all, so I suspect Varnish to be the culprit.

This build for Fedora illustrates both the purpose of this patch (as it works without access to @KristianLyng's blog =) and the inconsistent failure of `ban.sh`:
http://koji.fedoraproject.org/koji/taskinfo?taskID=6267552

_The failing build is the arm one, which I believe not to be supported by you, but that will be my responsibility as a maintainer to help it work._

One more thing, this patch uses `seq` which doesn't exist on FreeBSD IIRC. Since I don't run FreeBSD anywhere yet, I leave this fix to you. _/kthxbye_
