### PR TITLE
Do not set CURLOPT_NOBODY if we have data to send.

### DIFF
--- a/src/modules/curl.c
+++ b/src/modules/curl.c
@@ -124,7 +124,7 @@ static void issue_curl(void *priv, char *url, struct ipc_ret_t *ret)
 			curl_easy_setopt(curl, CURLOPT_READFUNCTION, senddata);
 			curl_easy_setopt(curl, CURLOPT_READDATA, private);
 		} else {
-			curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
+			curl_easy_setopt(curl, CURLOPT_NOBODY, 1);
 		}
 		res = curl_easy_perform(curl);
 		if(res != CURLE_OK) {


### PR DESCRIPTION
In libcurl version 7.15.5 will CURLOPT_NOBODY (when true) change the HTTP method from PUT to HEAD, even though CURLOPT_UPLOAD is true.

fixes #108
