### PR TITLE
 Don't crash on empty HTML files

### DIFF
--- a/src/modules/html.c
+++ b/src/modules/html.c
@@ -86,7 +86,6 @@ static unsigned int html_reply(struct http_request *request, void *data)
 	buffer = malloc(sbuf.st_size);
 	assert(buffer);
 	ret = read(fd, buffer, sbuf.st_size);
-	assert(ret>0);
 	assert(ret==sbuf.st_size);
 	resp = http_mkresp(request->connection, 200, NULL);
 	resp->data = buffer;


### PR DESCRIPTION
Fixes #119.

If you're wondering why we should have the ability to serve empty files, it's useful during development. For example, I created all my CSS/JS files as empty files and loaded them, so I could start development, and it causing vagent to crash. I don't think that's good behavior.

cc @fgsch 