### PR TITLE
[3.0] Redirect /html to /html/

### DIFF
--- a/include/http.h
+++ b/include/http.h
@@ -109,6 +109,7 @@ int send_response2(struct http_response *resp);
 
 int send_response_ok(struct MHD_Connection *connection, const char *data);
 int send_response_fail(struct MHD_Connection *connection, const char *data);
+int send_response_redirect(struct MHD_Connection *connection, const char *url);
 
 /*
  * URL    - the HTTP-protocol URL (e.g: req.url, not including host-header).

--- a/src/modules/html.c
+++ b/src/modules/html.c
@@ -59,6 +59,10 @@ static unsigned int html_reply(struct http_request *request, void *data)
 	struct http_response *resp;
 	struct html_priv_t *html;
 	GET_PRIV(data, html);
+	if (strcmp(request->url, "/html") == 0) {
+		send_response_redirect(request->connection, "/html/");
+		return 0;
+	}
 	const char *url_stub = (strlen(request->url) > strlen("/html/")) ? request->url + strlen("/html/") : "index.html";
 	if (url_stub[0] == '/' || strstr(url_stub,"/../") || !strncmp(url_stub,"../",strlen("../"))) {
 		send_response_fail(request->connection, "Invalid URL");
@@ -105,5 +109,5 @@ html_init(struct agent_core_t *core)
 	priv->logger = ipc_register(core,"logger");
 	plug->data = (void *)priv;
 	plug->start = NULL;
-	http_register_url(core, "/html/", M_GET, html_reply, core);
+	http_register_url(core, "/html", M_GET, html_reply, core);
 }

--- a/src/modules/http.c
+++ b/src/modules/http.c
@@ -199,6 +199,17 @@ int send_response_fail(struct MHD_Connection *connection, const char *data)
 	return send_response(connection, 500, data, strlen(data));
 }
 
+int send_response_redirect(struct MHD_Connection *connection, const char *url)
+{
+	assert(url);
+	struct http_response *resp = http_mkresp(connection, 301, NULL);
+	int ret;
+	http_add_header(resp, "Location", url);
+	ret = send_response2(resp);
+	http_free_resp(resp);
+	return ret;
+}
+
 static void request_completed (void *cls, struct MHD_Connection *connection,
 		   void **con_cls, enum MHD_RequestTerminationCode toe)
 {


### PR DESCRIPTION
This is a small usability enhancement to redirect `/html` to `/html/` instead of returning "Failed".

The reason we don't just serve content to `/html` is that many people implementing dashboards use URLs like this:

```
<link rel="stylesheet" href="assets/css/main.css">
```

If you request `http://localhost:6085/html/` that resolves to: 

```
http://localhost:6085/html/assets/css/main.css
```

However, if you request `http://localhost:6085/html` it resolves to: 

```
http://localhost:6085/assets/css/main.css
```

Which is incorrect. A redirect is the best solution.