### PR TITLE
[master] Add appropriate content type when serving HTML

### DIFF
--- a/include/http.h
+++ b/include/http.h
@@ -92,7 +92,13 @@ struct http_response {
 	unsigned int ndata;
 };
 
+struct http_content_type {
+	const char *file_ext;
+	const char *content_type;
+};
+
 void http_add_header(struct http_response *resp, const char *key, const char *value);
+void http_set_content_type(struct http_response *resp, const char *filepath);
 void http_free_resp(struct http_response *resp);
 struct http_response *http_mkresp(struct MHD_Connection *conn, int status, const char *body);
 /*

--- a/src/modules/html.c
+++ b/src/modules/html.c
@@ -91,6 +91,7 @@ static unsigned int html_reply(struct http_request *request, void *data)
 	resp = http_mkresp(request->connection, 200, NULL);
 	resp->data = buffer;
 	resp->ndata = ret;
+	http_set_content_type(resp, path);
 	send_response2(resp);
 	http_free_resp(resp);
 	return 0;

--- a/src/modules/http.c
+++ b/src/modules/http.c
@@ -68,6 +68,16 @@ struct connection_info_struct {
 	int authed;
 };
 
+struct http_content_type http_content_types[] = {
+	{".html", "text/html"},
+	{".js",   "text/javascript"},
+	{".css",  "text/css"},
+	{".jpg",  "image/jpeg"},
+	{".jpeg", "image/jpeg"},
+	{".png",  "image/png"},
+	{".gif",  "image/gif"}
+};
+
 static char *make_help(struct http_priv_t *http)
 {
 	char *body;
@@ -477,4 +487,21 @@ void http_init(struct agent_core_t *core)
 	plug->start = http_start;
 	priv->listener = NULL;
 	priv->help_page = NULL;
+}
+
+void http_set_content_type(struct http_response *resp, const char *filepath)
+{
+	char *ext = strrchr(filepath, '.');
+
+	if (ext) {
+		int i;
+
+		for (i = 0; i < sizeof(http_content_types) / sizeof(struct http_content_type); i++) {
+			if (strcmp(ext, http_content_types[i].file_ext) == 0) {
+				http_add_header(resp, "Content-Type", http_content_types[i].content_type);
+
+				break;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Google Chrome won't render the HTML page when you start vagent with the `-H` argument as their is no content type header (it's just rendered as plain text). This will fix that by detecting the appropriate content type for several common file formats.

I'm not sure how actively this repo is maintained, but if this gets merged I can make another PR against master (I'm stuck using Varnish 3). I also have some more fixes that I can send in.

See Also: https://github.com/varnish/vagent2/pull/123