### PR TITLE
[master] Send CORS headers to allow cross site requests

### DIFF
--- a/include/http.h
+++ b/include/http.h
@@ -97,6 +97,7 @@ struct http_content_type {
 	const char *content_type;
 };
 
+char *http_get_header(struct MHD_Connection *connection, const char *header);
 void http_add_header(struct http_response *resp, const char *key, const char *value);
 void http_set_content_type(struct http_response *resp, const char *filepath);
 void http_free_resp(struct http_response *resp);


### PR DESCRIPTION
This PR adds [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) to all responses so that HTML tools (e.g. dashboards) can be built that don't need to be served from the same domain as Varnish Agent, which is very useful in situations with multiple varnish servers or if you want to host your tools with something like Nginx/Apache (so you have access to FastCGI languages for example).

This will allow cross-site HTTP requests from ANY domain, which normally would be a security risk in an application like this where you have destructive capabilities. However, Varnish Agent forces you to use HTTP basic authentication, so that risk is mitigated. An attacker can only perform a cross-site request if they know the host, port, username, and password for varnish agent, at which point you have larger issues.

There is no way from the browser sandbox for a script to send a request without hard coding the credentials into the JavaScript, unless it's on the same domain (in which case this PR changes nothing).

I'm happy to answer any questions about this.