### PR TITLE
Use proper HTTP status codes

### DIFF
--- a/include/http.h
+++ b/include/http.h
@@ -113,6 +113,9 @@ int send_response(struct http_response *resp);
 
 int send_response_ok(struct MHD_Connection *connection, const char *data);
 int send_response_fail(struct MHD_Connection *connection, const char *data);
+int send_response_bad_request(struct MHD_Connection *connection, const char *data);
+int send_response_forbidden(struct MHD_Connection *connection, const char *data);
+int send_response_not_found(struct MHD_Connection *connection, const char *data);
 
 /*
  * URL    - the HTTP-protocol URL (e.g: req.url, not including host-header).

--- a/src/modules/html.c
+++ b/src/modules/html.c
@@ -60,20 +60,20 @@ static unsigned int html_reply(struct http_request *request, void *data)
 	GET_PRIV(data, html);
 	const char *url_stub = (strlen(request->url) > strlen("/html/")) ? request->url + strlen("/html/") : "index.html";
 	if (url_stub[0] == '/' || strstr(url_stub,"/../") || !strncmp(url_stub,"../",strlen("../"))) {
-		send_response_fail(request->connection, "Invalid URL");
+		send_response_bad_request(request->connection, "Invalid URL");
 		return 0;
 	}
 	snprintf(path, sizeof(path), "%s/%s", core->config->H_arg, url_stub);
 	ret = stat(path, &sbuf);
 	if (ret < 0) {
 		warnlog(html->logger, "Stat failed for %s. Errnno %d: %s.", path,errno,strerror(errno));
-		send_response_fail(request->connection, "stat() was not happy");
+		send_response_not_found(request->connection, "File not found");
 		return 0;
 	}
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
 		warnlog(html->logger, "open() failed for %s: %s", path, strerror(errno));
-		send_response_fail(request->connection, "open() was not happy");
+		send_response_forbidden(request->connection, "Could not open file");
 		return 0;
 	}
 	if (!S_ISREG(sbuf.st_mode)) {

--- a/src/modules/http.c
+++ b/src/modules/http.c
@@ -61,6 +61,9 @@ send_response_##name(struct MHD_Connection *conn, const char *data)	\
 	return (retval);						\
 }
 SEND(ok, 200)
+SEND(bad_request, 400)
+SEND(forbidden, 404)
+SEND(not_found, 404)
 SEND(fail, 500)
 
 struct http_listener {

--- a/src/modules/vban.c
+++ b/src/modules/vban.c
@@ -79,7 +79,7 @@ static unsigned int vban_reply(struct http_request *request, void *data)
 		else {
 			const char *path = request->url + strlen("/ban");
 			if (request->ndata != 0) {
-				send_response_fail(request->connection, "Banning with both a url and request body? Pick one or the other please.");
+				send_response_bad_request(request->connection, "Banning with both a url and request body? Pick one or the other please.");
 			} else {
 				assert(request->ndata == 0);
 				run_and_respond(vban->vadmin, request->connection, "ban " BAN_SHORTHAND "%s",path);

--- a/src/modules/vcl.c
+++ b/src/modules/vcl.c
@@ -301,10 +301,10 @@ static unsigned int vcl_reply(struct http_request *request, void *data)
 					}
 					result = strtok_r(NULL, "\n", &saveptr);
 				}
-				
-				if (activevcl == NULL) { 
+
+				if (activevcl == NULL) {
 					send_response_fail(request->connection, "No active VCL");
-				} else { 
+				} else {
 					strcpy(vret.answer,activevcl);
 					send_response_ok(request->connection, vret.answer);
 				}
@@ -314,7 +314,7 @@ static unsigned int vcl_reply(struct http_request *request, void *data)
 		} else if (!strcmp(request->url, "/vcl") || !strcmp(request->url,"/vcl/")) {
 			ipc_run(vcl->vadmin, &vret, "vcl.list");
 			if (vret.status == 400) {
-				send_response_fail(request->connection, vret.answer);
+				send_response_bad_request(request->connection, vret.answer);
 			} else {
 				send_response_ok(request->connection, vret.answer);
 			}
@@ -323,7 +323,7 @@ static unsigned int vcl_reply(struct http_request *request, void *data)
 		} else if (!strncmp(request->url,"/vcl/",strlen("/vcl/"))) {
 			ipc_run(vcl->vadmin, &vret, "vcl.show %s", request->url + strlen("/vcl/"));
 			if (vret.status == 400) {
-				send_response_fail(request->connection, vret.answer);
+				send_response_bad_request(request->connection, vret.answer);
 			} else {
 				send_response_ok(request->connection, vret.answer);
 			}
@@ -333,7 +333,7 @@ static unsigned int vcl_reply(struct http_request *request, void *data)
 			struct vsb *json;
 			ipc_run(vcl->vadmin, &vret, "vcl.list");
 			if (vret.status == 400) {
-				send_response_fail(request->connection, vret.answer);
+				send_response_bad_request(request->connection, vret.answer);
 			} else {
 				json = vcl_list_json(vret.answer);
 				assert(VSB_finish(json) == 0);
@@ -349,7 +349,7 @@ static unsigned int vcl_reply(struct http_request *request, void *data)
 			free(vret.answer);
 			return 0;
 		} else {
-			send_response_fail(request->connection, "Invalid VCL-url.");
+			send_response_not_found(request->connection, "Invalid VCL-url.");
 			return 0;
 		}
 	} else if (request->method == M_POST) {
@@ -371,9 +371,7 @@ static unsigned int vcl_reply(struct http_request *request, void *data)
 				free(vret.answer);
 				return 0;
 			} else {
-				resp = http_mkresp(request->connection, 400, "Bad URL?");
-				send_response(resp);
-				http_free_resp(resp);
+				send_response_bad_request(request->connection, "Bad URL?");
 				return 0;
 			}
 		} else if (!strncmp(request->url, "/vcldeploy/",strlen("/vcldeploy/"))) {
@@ -404,7 +402,7 @@ static unsigned int vcl_reply(struct http_request *request, void *data)
 			return 0;
 		}
 	} else {
-		return send_response_fail(request->connection, "Unknown request?");
+		return send_response_bad_request(request->connection, "Unknown request?");
 	}
 	assert("Shouldn't get here" == NULL);
 	return 0;

--- a/src/modules/vlog.c
+++ b/src/modules/vlog.c
@@ -37,7 +37,7 @@
  *
  * We plan on doing a proper vlog module sometime down the line, where we
  * properly leverage the flexibility of the new logging API in Varnish 4.0.
- *  
+ *
  */
 
 #include <errno.h>
@@ -117,7 +117,7 @@ static int vlog_cb_func(struct VSL_data *vsl,
 			vrp->entries++;
 		}
 	}
-	
+
 	return (0);
 }
 
@@ -146,7 +146,7 @@ static unsigned int vlog_reply(struct http_request *request, void *data)
 	enum VSL_grouping_e grouping = VSL_g_request;
 	struct agent_core_t *core = data;
 	GET_PRIV(data, vlog);
- 	
+
 	p = next_slash(request->url + 1);
 	if (p) {
 		char *lim = strdup(p);
@@ -157,7 +157,7 @@ static unsigned int vlog_reply(struct http_request *request, void *data)
 		int j = sscanf(lim, "%u", &vrp.limit);
 		if(j != 1) {
 			free(lim);
-			send_response_fail(request->connection, "Not a number");
+			send_response_bad_request(request->connection, "Not a number");
 			return 0;
 		}
 
@@ -178,7 +178,7 @@ static unsigned int vlog_reply(struct http_request *request, void *data)
 		if (tmp2 && *tmp2) *tmp2 = '\0';
 		p = next_slash(p);
 	}
-	
+
 	vrp.answer = VSB_new_auto();
 	assert(vrp.answer != NULL);
 
@@ -199,13 +199,13 @@ static unsigned int vlog_reply(struct http_request *request, void *data)
 		send_response_fail(request->connection, VSB_data(vrp.answer));
 		goto cleanup;
 	}
-	
+
 	vsl = VSL_New();
 	assert(vsl);
 
 	if (tag) {
 		grouping = VSL_g_raw;
-		
+
 		if (VSL_Arg(vsl, 'i', tag) < 0) {
 			VSB_printf(vrp.answer, "Unable to specify tag '%s': %s",
 			    tag, VSL_Error(vsl));
@@ -228,7 +228,7 @@ static unsigned int vlog_reply(struct http_request *request, void *data)
 		goto cleanup;
 	}
 
-	
+
 	vslq = VSLQ_New(vsl, &c, grouping, NULL);
 	if (vslq == NULL) {
 		VSB_clear(vrp.answer);


### PR DESCRIPTION
Sorry about the extra whitespace, I can remove it if necessary (my editor auto trims whitespace).

I've updated code to use proper HTTP status codes where applicable (instead of HTTP 500 for everything). Since JavaScript XHR requests treat anything over HTTP 400 as an error, this shouldn't break any dashboards.

Also used more clear wording for the errors from /html/

cc @fgsch 