### PR TITLE
Add a new `-a` option for the VAC registration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,8 @@ SYNOPSIS
         varnish-agent -K agentsecretfile [-p directory] [-H directory]
                       [-n name] [-c port] [-S file] [-T host:port]
                       [-t timeout] [-h] [-P pidfile] [-V] [-u user]
-                      [-g group] [-z http://vac_register_url] [-q] [-v]
+                      [-g group] [-z http://vac_register_url] [-a host]
+                      [-q] [-v]
 
 DESCRIPTION
 ===========
@@ -92,6 +93,8 @@ OPTIONS
 
 -z vac_register_url
             Specify the callback vac register url.
+
+-a host     The host name the VAC shoul use to reach the agent.
 
 VARNISH CONFIGURATION
 =====================

--- a/include/common.h
+++ b/include/common.h
@@ -53,6 +53,7 @@ struct agent_config_t {
 	char *H_arg; // HTML directory
 	char *P_arg; // Pid file
 	char *vac_arg;
+	char *a_arg; // Accept host name for VAC requests
 	char *password;
 	char *user;
 	char *userpass;

--- a/src/main.c
+++ b/src/main.c
@@ -121,6 +121,7 @@ static void usage(const char *argv0)
 	"-v                    Verbose mode. Output everything.\n"
 	"-K agentsecretfile    File containing username:password for authentication\n"
 	"-z http://host:port   VAC interface.\n"
+	"-a host               The host name the VAC should call back.\n"
 	"\n"
 	"All arguments are optional.\n"
 	, argv0);
@@ -145,9 +146,10 @@ static void core_opt(struct agent_core_t *core, int argc, char **argv)
 	core->config->H_arg = strdup(AGENT_HTML_DIR);
 	core->config->P_arg = NULL;
 	core->config->vac_arg= NULL;
+	core->config->a_arg = NULL;
 	core->config->K_arg = strdup("/etc/varnish/agent_secret");
 	core->config->loglevel = 2;
-	while ((opt = getopt(argc, argv, "VhdP:p:H:n:S:T:t:c:u:g:z:K:qv")) != -1) {
+	while ((opt = getopt(argc, argv, "VhdP:p:H:n:S:T:t:c:u:g:z:a:K:qv")) != -1) {
 		switch (opt) {
 		case 'q':
 			core->config->loglevel = 1;
@@ -204,6 +206,9 @@ static void core_opt(struct agent_core_t *core, int argc, char **argv)
 			break;
 		case 'z':
 			core->config->vac_arg = strdup(optarg);
+			break;
+		case 'a':
+			core->config->a_arg = optarg;
 			break;
 		}
 	}

--- a/src/modules/vac_register.c
+++ b/src/modules/vac_register.c
@@ -65,6 +65,10 @@ static void generate_json(struct vac_register_priv_t *priv)
 	VSB_quote(priv->vsb_out, priv->core->config->password, strlen(priv->core->config->password), 0);
 	VSB_printf(priv->vsb_out, ",\n");
 	VSB_printf(priv->vsb_out, "\t\"dash-n\": \"%s\"\n", priv->core->config->n_arg ? priv->core->config->n_arg : "");
+
+	if (priv->core->config->a_arg != NULL)
+		VSB_printf(priv->vsb_out, "\t\"hostname\": \"%s\",\n", priv->core->config->a_arg);
+
 	VSB_printf(priv->vsb_out, "}\n");
 	assert(VSB_finish(priv->vsb_out) == 0);
 }


### PR DESCRIPTION
I haven't tested it yet, I'm not sure I can actually check the contents of the vac_register request with the existing test fixtures. I can add the commits later to cover the -a option.

I haven't enforced rules such as:
- `-a` cannot be set without `-z`
- the host name should resolve the agent's machine

Feedback first :)