### PR TITLE
tests/authfail.sh need strace

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,8 @@ Build-Depends: debhelper (>= 7),
  libcurl4-gnutls-dev | libcurl-dev,
  libwww-perl,
  python-demjson,
- net-tools
+ net-tools,
+ strace
 Standards-Version: 3.8.1
 
 Package: varnish-agent


### PR DESCRIPTION
The test suite fail if strace is not installed, i've "documented" this in your debian/control.