### PR TITLE
MHD_create_response_from_data() is deprecated since microhttpd 0.9.5

### DIFF
--- a/src/modules/http.c
+++ b/src/modules/http.c
@@ -212,8 +212,13 @@ send_response(struct http_response *resp)
 	char *origin;
 	int ret;
 
+#if (MHD_VERSION >= 0x00090500)
+	response = MHD_create_response_from_buffer(resp->ndata,
+	    (void *)resp->data, MHD_RESPMEM_MUST_COPY);
+#else
 	response = MHD_create_response_from_data(resp->ndata,
 	    (void *)resp->data, MHD_NO, MHD_YES);
+#endif
 	assert(response);
 	for (hdr = resp->headers; hdr; hdr = hdr->next)
 		MHD_add_response_header(response, hdr->key, hdr->value);


### PR DESCRIPTION
microhttpd MHD_create_response_from_data() is replaced by **MHD_create_response_from_buffer()** since version **0.9.5**.
Please note that your travis test use Ubuntu 12.04 Precise with microhttpd version **0.4.6** so my modification will not be tested properly (but without that i can't build vagent2 on Debian with microhttpd 0.9.44).

Sources:
* https://www.gnu.org/software/libmicrohttpd/manual/html_node/microhttpd_002dresponse-create.html#index-MHD_005fcreate_005fresponse_005ffrom_005fdata-101
* http://packages.ubuntu.com/search?keywords=libmicrohttpd-dev