### PR TITLE
Fixes gh-182: Adding parameter -k to allow the agent to talk with self-signed VAC's.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ SYNOPSIS
 ::
 
         varnish-agent [-C cafile] [-c port] [-d] [-g group] [-H directory]
-                      [-h] [-K agent-secret-file] [-n name] [-P pidfile]
+                      [-h] [-k allow-insecure-vac][-K agent-secret-file] [-n name] [-P pidfile]
                       [-p directory] [-q] [-r] [-S varnishd-secret-file]
                       [-T host:port] [-t timeout] [-u user] [-V] [-v]
                       [-z vac_register_url]
@@ -64,6 +64,10 @@ OPTIONS
             concept front end.
 
 -h          Print help.
+
+-k allow-insecure-vac
+            This option explicitly allows curl to perform 'insecure' SSL
+            connections and transfers.
 
 -K agent-secret-file
             Path to a file containing a single line representing the

--- a/include/common.h
+++ b/include/common.h
@@ -51,6 +51,7 @@ struct agent_config_t {
 	int loglevel;
 	const char *c_arg; // Listening port for incoming requests
 	char *C_arg; // CURLOPT_CAINFO param
+	int k_arg; // CURLOPT_SSL_VERIFYPEER param
 	const char *p_arg; // Persistence directory
 	const char *H_arg; // HTML directory
 	char *P_arg; // Pid file

--- a/src/main.c
+++ b/src/main.c
@@ -112,6 +112,7 @@ usage(const char *argv0)
 	    "    -g group              Group to run as (default: varnish)\n"
 	    "    -H directory          Where /html/ is located. Default: " AGENT_HTML_DIR "\n"
 	    "    -h                    This help.\n"
+	    "    -k                    This option explicitly allows curl to perform 'insecure' SSL connections and transfers.\n"
 	    "    -K agent-secret-file  File containing username:password for authentication.\n"
 	    "                          Default: " AGENT_CONF_DIR "/agent_secret\n"
 	    "    -n name               Name. Should match varnishd -n option.\n"
@@ -147,7 +148,8 @@ core_opt(struct agent_core_t *core, int argc, char **argv)
 	core->config->H_arg = AGENT_HTML_DIR;
 	core->config->K_arg = AGENT_CONF_DIR "/agent_secret";
 	core->config->loglevel = 2;
-	while ((opt = getopt(argc, argv, "C:c:dg:H:hK:n:P:p:qrS:T:t:u:Vvz:")) != -1) {
+	core->config->k_arg = 0;
+	while ((opt = getopt(argc, argv, "C:c:dg:H:hkK:n:P:p:qrS:T:t:u:Vvz:")) != -1) {
 		switch (opt) {
 		case 'C':
 			core->config->C_arg = optarg;
@@ -169,6 +171,9 @@ core_opt(struct agent_core_t *core, int argc, char **argv)
 			exit(1);
 		case 'K':
 			core->config->K_arg = optarg;
+			break;
+		case 'k':
+			core->config->k_arg = 1;
 			break;
 		case 'n':
 			core->config->n_arg = optarg;
@@ -340,7 +345,7 @@ main(int argc, char **argv)
 	core_opt(&core, argc, argv);
 	base64_init();
 	core_plugins(&core);
-	
+
 	if (core.config->P_arg)
 		p_open(&pfh, core.config->P_arg);
 
@@ -349,7 +354,7 @@ main(int argc, char **argv)
 		logger(-1, "Plugins initialized. -d argument given, so not forking.");
 	else
 		v_daemon(&pfh);
-		
+
 	if (pfh)
 		pidfile_write(pfh);
 	ipc_sanity(&core);

--- a/src/modules/curl.c
+++ b/src/modules/curl.c
@@ -40,6 +40,7 @@ struct curl_priv_t {
 	void *data;
 	char *pos;
 	char *cainfo;
+	int skipsslverifypeer;
 	unsigned int ndata;
 };
 
@@ -118,6 +119,8 @@ issue_curl(void *priv, char *url, struct ipc_ret_t *ret)
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, dropdata);
 		if (private->cainfo)
 			curl_easy_setopt(curl, CURLOPT_CAINFO, private->cainfo);
+		if (private->skipsslverifypeer == 1)
+			curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
 		if (data) {
 			curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
 			curl_easy_setopt(curl, CURLOPT_UPLOAD, 1);
@@ -156,6 +159,7 @@ curl_init(struct agent_core_t *core)
 	plug = plugin_find(core, "curl");
 	priv->logger = ipc_register(core, "logger");
 	priv->cainfo = core->config->C_arg;
+	priv->skipsslverifypeer = core->config->k_arg;
 	plug->data = (void *)priv;
 	plug->start = ipc_start;
 	plug->ipc->priv = priv;


### PR DESCRIPTION
Using parameter -k is the same -k, used by curl to allow insecure connections.