### PR TITLE
Stats push configurable timeout.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,10 @@ OPTIONS
 
 -u user     User to run as. Defaults to ``varnish``.
 
+-w curl-timeout
+            Timeout in seconds used for sending stats against the VAC.
+            Defaults to 2 seconds.
+
 -V          Print version.
 
 -v          Verbose mode. Be extra chatty, including all CLI chatter.

--- a/include/common.h
+++ b/include/common.h
@@ -54,6 +54,7 @@ struct agent_config_t {
 	const char *remote_port; // Port to connect to from the outside
 	char *C_arg; // CURLOPT_CAINFO param
 	int k_arg; // CURLOPT_SSL_VERIFYPEER param
+	long w_arg; // CURLOPT_TIMEOUT param
 	const char *p_arg; // Persistence directory
 	const char *H_arg; // HTML directory
 	char *P_arg; // Pid file

--- a/src/main.c
+++ b/src/main.c
@@ -141,6 +141,7 @@ core_opt(struct agent_core_t *core, int argc, char **argv)
 	int opt;
 	char *sep;
 	const char *argv0 = argv[0];
+	long curl_timeout;
 
 	assert(core->config != NULL);
 
@@ -222,7 +223,9 @@ core_opt(struct agent_core_t *core, int argc, char **argv)
 			core->config->timeout = strtod(optarg, NULL);
 			break;
 		case 'w':
-			core->config->w_arg = strtol(optarg, NULL, 10);
+			curl_timeout = strtol(optarg, NULL, 10);
+			if (curl_timeout > 0)
+				core->config->w_arg = curl_timeout; 
 			break;
 		case 'u':
 			core->config->u_arg = optarg;

--- a/src/main.c
+++ b/src/main.c
@@ -128,6 +128,7 @@ usage(const char *argv0)
 	    "    -T host:port          Varnishd administrative interface.\n"
 	    "    -t timeout            Timeout for talking to varnishd (default: 5 seconds).\n"
 	    "    -u user               User to run as (default: varnish)\n"
+	    "    -w curl-timeout       Timeout for pushing stats against the VAC (default: 2 seconds).\n"
 	    "    -V                    Print version.\n"
 	    "    -v                    Verbose mode. Output everything.\n"
 	    "    -z vac_register_url   VAC interface.\n\n",
@@ -148,6 +149,7 @@ core_opt(struct agent_core_t *core, int argc, char **argv)
 	core->config->bind_address = "0.0.0.0";
 	core->config->local_port = "6085";
 	core->config->remote_port = "6085";
+	core->config->w_arg = 2;
 	core->config->timeout = 5;
 	core->config->p_arg = AGENT_PERSIST_DIR;
 	core->config->H_arg = AGENT_HTML_DIR;
@@ -156,7 +158,7 @@ core_opt(struct agent_core_t *core, int argc, char **argv)
 	core->config->k_arg = 0;
 	core->config->n_arg = strdup("");
 	AN(core->config->n_arg);
-	while ((opt = getopt(argc, argv, "a:C:c:dg:H:hkK:n:P:p:qrS:T:t:u:Vvz:")) != -1) {
+	while ((opt = getopt(argc, argv, "a:C:c:dg:H:hkK:n:P:p:qrS:T:t:u:w:Vvz:")) != -1) {
 		switch (opt) {
 		case 'a':
 			core->config->bind_address = optarg;
@@ -218,6 +220,9 @@ core_opt(struct agent_core_t *core, int argc, char **argv)
 			break;
 		case 't':
 			core->config->timeout = strtod(optarg, NULL);
+			break;
+		case 'w':
+			core->config->w_arg = strtol(optarg, NULL, 10);
 			break;
 		case 'u':
 			core->config->u_arg = optarg;

--- a/src/modules/curl.c
+++ b/src/modules/curl.c
@@ -42,6 +42,7 @@ struct curl_priv_t {
 	char *cainfo;
 	int skipsslverifypeer;
 	unsigned int ndata;
+	long timeout;
 };
 
 static size_t
@@ -113,7 +114,7 @@ issue_curl(void *priv, char *url, struct ipc_ret_t *ret)
 		curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
 		curl_easy_setopt(curl, CURLOPT_URL, url);
-		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 2);
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, private->timeout);
 		curl_easy_setopt(curl, CURLOPT_VERBOSE, 0);
 		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, dropdata);
@@ -160,6 +161,7 @@ curl_init(struct agent_core_t *core)
 	priv->logger = ipc_register(core, "logger");
 	priv->cainfo = core->config->C_arg;
 	priv->skipsslverifypeer = core->config->k_arg;
+	priv->timeout = core->config->w_arg;
 	plug->data = (void *)priv;
 	plug->start = ipc_start;
 	plug->ipc->priv = priv;


### PR DESCRIPTION
Sending stats to the vac has a default request timeout
of 2 seconds. Even though this is quite a generous timeout, it turns
out it needs to be configurable.

The motivation for this parameter is [here](https://varnish.zendesk.com/agent/tickets/16165).

The gather attached in the above ticket shows a lot of the following lines:

```
Feb 18 13:13:43 cache07 varnish-agent[104276]: issue_curl (modules/curl.c:109): Issuing curl command with url=http://vac01.back.nm.cbc.ca:81/api/rest/cache/5b917595e03612ae5aa9956c/stats. Request body present
Feb 18 13:13:45 cache07 varnish-agent[104276]: issue_curl (modules/curl.c:136): Curl callback failed with status code 28
Feb 18 13:13:45 cache07 varnish-agent[104276]: push_stats (modules/vstat.c:246): cURL returned 500: Curl callback failed with status code 28
```

